### PR TITLE
Fix default value for lists

### DIFF
--- a/core/commonMain/src/Descriptors.kt
+++ b/core/commonMain/src/Descriptors.kt
@@ -46,7 +46,7 @@ internal abstract class Descriptor<T : Any, TResult>(val type: ArgType<T>,
      * Flag to check if descriptor has set default value for option/argument.
      */
     val defaultValueSet by lazy {
-        defaultValue != null && (defaultValue is List<*> && defaultValue.isNotEmpty() || defaultValue !is List<*>)
+        defaultValue != null
     }
 }
 


### PR DESCRIPTION
This condition is wrong, empty list should be permitted to be default value as all other concrete values can be. And in my case it is default value. What's more this condition didn't prevent other collections from having default value of empty collection e. g. `Set`, `Map`, `Collection`.