### PR TITLE
Fix `ArgType.Boolean::convert` function

### DIFF
--- a/core/commonMain/src/ArgType.kt
+++ b/core/commonMain/src/ArgType.kt
@@ -33,7 +33,8 @@ abstract class ArgType<T : Any>(val hasParameter: kotlin.Boolean) {
             get() = ""
 
         override fun convert(value: kotlin.String, name: kotlin.String): kotlin.Boolean =
-            value != "false"
+            runCatching { value.lowercase().toBooleanStrict() }
+                .getOrElse { throw ParsingException("Option $name is expected to be boolean value. $value is provided.") }
     }
 
     /**

--- a/core/commonTest/src/ArgTypeBooleanTest.kt
+++ b/core/commonTest/src/ArgTypeBooleanTest.kt
@@ -1,0 +1,51 @@
+package kotlinx.cli
+
+import kotlin.test.*
+
+class ArgTypeBooleanTest {
+    private fun message(value: String, name: String) =
+        "Option $name is expected to be boolean value. $value is provided."
+
+    @Test
+    fun testConvert() {
+        //@formatter:off
+        assertEquals(true, ArgType.Boolean.convert("true", ""))
+        assertEquals(true, ArgType.Boolean.convert("True", ""))
+        assertEquals(true, ArgType.Boolean.convert("TRUE", ""))
+        assertEquals(true, ArgType.Boolean.convert("tRuE", ""))
+        assertEquals(true, ArgType.Boolean.convert("true", "OptionName"))
+        assertEquals(true, ArgType.Boolean.convert("True", "OptionName"))
+        assertEquals(true, ArgType.Boolean.convert("TRUE", "OptionName"))
+        assertEquals(true, ArgType.Boolean.convert("tRuE", "OptionName"))
+
+        assertEquals(false, ArgType.Boolean.convert("false", ""))
+        assertEquals(false, ArgType.Boolean.convert("False", ""))
+        assertEquals(false, ArgType.Boolean.convert("FALSE", ""))
+        assertEquals(false, ArgType.Boolean.convert("fAlSe", ""))
+        assertEquals(false, ArgType.Boolean.convert("false", "OptionName"))
+        assertEquals(false, ArgType.Boolean.convert("False", "OptionName"))
+        assertEquals(false, ArgType.Boolean.convert("FALSE", "OptionName"))
+        assertEquals(false, ArgType.Boolean.convert("fAlSe", "OptionName"))
+
+        assertFailsWith<ParsingException>(message("", "")) { ArgType.Boolean.convert("", "") }
+        assertFailsWith<ParsingException>(message("0", "")) { ArgType.Boolean.convert("0", "") }
+        assertFailsWith<ParsingException>(message("1", "")) { ArgType.Boolean.convert("1", "") }
+        assertFailsWith<ParsingException>(message("yes", "")) { ArgType.Boolean.convert("yes", "") }
+        assertFailsWith<ParsingException>(message("no", "")) { ArgType.Boolean.convert("no", "") }
+        assertFailsWith<ParsingException>(message("on", "")) { ArgType.Boolean.convert("on", "") }
+        assertFailsWith<ParsingException>(message("off", "")) { ArgType.Boolean.convert("off", "") }
+        assertFailsWith<ParsingException>(message("hello", "")) { ArgType.Boolean.convert("hello", "") }
+        assertFailsWith<ParsingException>(message("IntellĲ", "")) { ArgType.Boolean.convert("IntellĲ", "") }
+
+        assertFailsWith<ParsingException>(message("", "OptionName")) { ArgType.Boolean.convert("", "OptionName") }
+        assertFailsWith<ParsingException>(message("0", "OptionName")) { ArgType.Boolean.convert("0", "OptionName") }
+        assertFailsWith<ParsingException>(message("1", "OptionName")) { ArgType.Boolean.convert("1", "OptionName") }
+        assertFailsWith<ParsingException>(message("yes", "OptionName")) { ArgType.Boolean.convert("yes", "OptionName") }
+        assertFailsWith<ParsingException>(message("no", "OptionName")) { ArgType.Boolean.convert("no", "OptionName") }
+        assertFailsWith<ParsingException>(message("on", "OptionName")) { ArgType.Boolean.convert("on", "OptionName") }
+        assertFailsWith<ParsingException>(message("off", "OptionName")) { ArgType.Boolean.convert("off", "OptionName") }
+        assertFailsWith<ParsingException>(message("hello", "OptionName")) { ArgType.Boolean.convert("hello", "OptionName") }
+        assertFailsWith<ParsingException>(message("IntellĲ", "")) { ArgType.Boolean.convert("IntellĲ", "OptionName") }
+        //@formatter:on
+    }
+}


### PR DESCRIPTION
Since anything which is not exactly "false" was considered to be `true`, it could lead to errors in program behaviour for end users. For example, "0", "no", "hello", and (ridiculously) "False" were parsed as `true`.

This commit changes the function behaviour to case-insensitively parse "true" as `true`, "false" as `false`, and throw ParsingException for anything else.